### PR TITLE
Reorganize FileHeader and FileFooter

### DIFF
--- a/ebi/src/format.rs
+++ b/ebi/src/format.rs
@@ -130,22 +130,18 @@ pub mod uncompressed;
 pub struct FileHeader {
     /// EBI1
     pub magic_number: [u8; 4],
-    /// unaligned
-    ///
-    /// major, minor, patch
-    pub version: [u16; 3],
-    /// unaligned
-    ///
+    pub config: FileConfig,
     /// Bytes offset for FileFooter from the file start.
     pub footer_offset: u64,
-    pub config: FileConfig,
+    /// major, minor, patch
+    pub version: [u16; 3],
 }
 
 #[repr(C, packed(1))]
 pub struct FileConfig {
-    pub field_type: FieldType, // = u8
-    pub chunk_option: ChunkOption,
+    pub field_type: FieldType,                 // = u8
     pub compression_scheme: CompressionScheme, // = u8
+    pub chunk_option: ChunkOption,
 }
 
 #[repr(u8)]
@@ -157,7 +153,7 @@ pub enum FieldType {
 #[repr(C, packed(1))]
 pub struct ChunkOption {
     pub kind: ChunkOptionKind, // u8
-    /// unaligned
+    pub reserved: u8,
     pub value: u64,
 }
 
@@ -216,6 +212,8 @@ pub struct FileFooter1 {
 
 #[repr(C, packed(1))]
 pub struct FileFooter2 {
+    /// Compression Elapsed Time (nano seconds)
+    pub compression_elapsed_time_nano_secs: u128,
     pub crc: u32,
 }
 

--- a/ebi/src/format/native.rs
+++ b/ebi/src/format/native.rs
@@ -9,7 +9,7 @@ use super::{
     ChunkFooter, CompressionScheme, FieldType, FileConfig, FileFooter0, FileFooter2, FileHeader,
 };
 
-#[derive(Getters, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Getters, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NativeFileHeader {
     /// EBI1
     magic_number: [u8; 4],
@@ -39,7 +39,7 @@ impl From<&FileHeader> for NativeFileHeader {
     }
 }
 
-#[derive(Getters, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Getters, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NativeFileConfig {
     pub field_type: FieldType, // = u8
     pub chunk_option: ChunkOption,
@@ -74,6 +74,8 @@ pub struct NativeFileFooter {
     number_of_chunks: u64,
     chunk_footers: Vec<NativeChunkFooter>,
     #[getter(skip)]
+    compression_elapsed_time_nano_secs: u128,
+    #[getter(skip)]
     crc: u32,
 }
 
@@ -86,11 +88,13 @@ impl NativeFileFooter {
         let number_of_records = footer0.number_of_records;
         let number_of_chunks = footer0.number_of_chunks;
         let chunk_footers = chunk_footers.iter().map(NativeChunkFooter::from).collect();
+        let compression_elapsed_time_nano_secs = footer2.compression_elapsed_time_nano_secs;
         let crc = footer2.crc;
         Self {
             number_of_records,
             number_of_chunks,
             chunk_footers,
+            compression_elapsed_time_nano_secs,
             crc,
         }
     }
@@ -101,6 +105,10 @@ impl NativeFileFooter {
 
     pub fn number_of_chunks(&self) -> u64 {
         self.number_of_chunks
+    }
+
+    pub fn compression_elapsed_time_nano_secs(&self) -> u128 {
+        self.compression_elapsed_time_nano_secs
     }
 
     pub fn crc(&self) -> u32 {

--- a/ebi/src/lib.rs
+++ b/ebi/src/lib.rs
@@ -62,6 +62,10 @@ mod tests {
         let footer_offset_slot_offset = file_writer.footer_offset_slot_offset();
         out_f.seek(SeekFrom::Start(footer_offset_slot_offset as u64))?;
         file_writer.write_footer_offset(&mut out_f)?;
+
+        let elapsed_time_slot_offset = file_writer.elapsed_time_slot_offset();
+        out_f.seek(SeekFrom::Start(elapsed_time_slot_offset as u64))?;
+        file_writer.write_elapsed_time(&mut out_f)?;
         // you can flush if you want
         out_f.flush()?;
 


### PR DESCRIPTION
 - Reorder FileHeader to align each fields
 - Add `compression_elapsed_time_nano_secs` field to FileFooter