### PR TITLE
Fix Gorilla Compression with >= 32 leading_zeroes

### DIFF
--- a/ebi/src/compressor/gorilla.rs
+++ b/ebi/src/compressor/gorilla.rs
@@ -179,7 +179,11 @@ pub(crate) mod modified_tsz {
 
                 self.state.total_bits_buffered += 1;
 
-                let leading_zeroes = xor.leading_zeros();
+                let mut leading_zeroes = xor.leading_zeros();
+                // we cannot encode leading_zeroes more than 32 bits in 5 bit.
+                if leading_zeroes >= 32 {
+                    leading_zeroes = 31;
+                }
                 let trailing_zeroes = xor.trailing_zeros();
 
                 if leading_zeroes >= self.state.leading_zeroes

--- a/ebi/src/decoder/chunk_reader/chimp.rs
+++ b/ebi/src/decoder/chunk_reader/chimp.rs
@@ -175,7 +175,6 @@ impl<R: BitRead> ChimpDecoder<R> {
                 if significant_bits == 0 {
                     significant_bits = 64;
                 }
-                dbg!(significant_bits, self.stored_leading_zeros);
                 self.stored_trailing_zeros = 64 - significant_bits - self.stored_leading_zeros;
                 let value = self.bit_reader.read_bits(
                     (64 - self.stored_leading_zeros - self.stored_trailing_zeros) as u8,

--- a/ebi/src/decoder/chunk_reader/chimp_n.rs
+++ b/ebi/src/decoder/chunk_reader/chimp_n.rs
@@ -215,7 +215,6 @@ impl<const N_PREVIOUS_VALUES: usize, R: BitRead> ChimpNDecoder<N_PREVIOUS_VALUES
                 if significant_bits == 0 {
                     significant_bits = 64;
                 }
-                dbg!(significant_bits, self.stored_leading_zeros);
                 self.stored_trailing_zeros =
                     64 - significant_bits as u32 - self.stored_leading_zeros;
                 let value = self.bit_reader.read_bits(


### PR DESCRIPTION
 - make sure to treat xor value which has more than or equal to 32 bits of leading_zeroes as 31 bits of leading_zeroes.
   - this is necessarry, because leading_zeroes are encoded in 5 bits.
 - Add corresponding tests for this.
   - Specifically values whose xors will have >= 32 bits leading_zeroes